### PR TITLE
Migrate to ESM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+dist/
 node_modules/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ const privateMethods = require('acorn-private-methods');
 Parser.extend(privateMethods).parse('class X { #a() {} }');
 ```
 
+or as an ECMAScript Module:
+
+```javascript
+import {Parser} from 'acorn';
+import privateMethods from 'acorn-private-methods';
+Parser.extend(privateMethods).parse('class X { #a() {} }');
+```
+
 ## License
 
 This plugin is released under an [MIT License](./LICENSE).

--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
-"use strict"
+import privateClassElements from "acorn-private-class-elements";
 
-const privateClassElements = require("acorn-private-class-elements")
-
-module.exports = function(Parser) {
+export default function privateMethods(Parser) {
   const ExtendedParser = privateClassElements(Parser)
 
   return class extends ExtendedParser {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "contributors": [
     "Adrian Heine <mail@adrianheine.de>"
   ],
+  "main": "dist/acorn-private-methods.js",
+  "module": "dist/acorn-private-methods.mjs",
   "engines": {
     "node": ">=4.8.2"
   },
@@ -14,6 +16,7 @@
   },
   "license": "MIT",
   "scripts": {
+    "build": "rollup -c rollup.config.js",
     "test": "mocha",
     "test:test262": "node run_test262.js",
     "lint": "eslint -c .eslintrc.json ."
@@ -24,12 +27,13 @@
   "dependencies": {
     "acorn-private-class-elements": "^0.2.6"
   },
-  "version": "0.3.2",
+  "version": "0.3.3",
   "devDependencies": {
     "acorn": "^7",
     "eslint": "^7",
     "eslint-plugin-node": "^11",
     "mocha": "^8",
+    "rollup": "^2.10.0",
     "test262": "git+https://github.com/tc39/test262.git#adf2cf4204a748463cacb68f07d0d006b00c3821",
     "test262-parser-runner": "^0.5.0"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,15 @@
+export default {
+  input: "index.js",
+  output: [
+    {
+      file: "dist/acorn-private-methods.js",
+      format: "cjs",
+      sourcemap: true
+    },
+    {
+      file: "dist/acorn-private-methods.mjs",
+      format: "es",
+      sourcemap: true
+    }
+  ]
+}


### PR DESCRIPTION
We've recently migrated Chrome DevTools to ESM, and have traditionally
been using acorn as the parser for various features including the
prettifier. In the context of https://crbug.com/1084349we are looking
into including private fields support in Chrome DevTools via this
plugin, and in order to make that easier with our build system, I've
added support for ESM output here in addition to the CJS output.

(Basically the same change as
https://github.com/acornjs/acorn-numeric-separator/pull/2)