### PR TITLE
Update AST node names to match ESTree [breaking change]

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a plugin for [Acorn](http://marijnhaverbeke.nl/acorn/) - a tiny, fast JavaScript parser, written completely in JavaScript.
 
-It implements support for private methods, getters and setters as defined in the stage 3 proposal [Private methods and getter/setters for JavaScript classes](https://github.com/tc39/proposal-private-methods). The emitted AST follows [an ESTree proposal](https://github.com/estree/estree/pull/180).
+It implements support for private methods, getters and setters as defined in the stage 3 proposal [Private methods and getter/setters for JavaScript classes](https://github.com/tc39/proposal-private-methods). The emitted AST follows the [ESTree experimental Class Features design](https://github.com/estree/estree/blob/master/experimental/class-features.md).
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ export default function privateMethods(Parser) {
     }
 
     parsePropertyName(prop) {
-      const isPrivate = this.options.ecmaVersion >= 8 && this._inClassMemberName && this.type == this.privateNameToken && !prop.static
+      const isPrivate = this.options.ecmaVersion >= 8 && this._inClassMemberName && this.type == this.privateIdentifierToken && !prop.static
       this._inClassMemberName = false
       if (!isPrivate) return super.parsePropertyName(prop)
       return this.parsePrivateClassElementName(prop)

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "acorn": "^6 || ^7 || ^8"
   },
   "dependencies": {
-    "acorn-private-class-elements": "^0.2.7"
+    "acorn-private-class-elements": "^1.0.0"
   },
-  "version": "0.3.3",
+  "version": "1.0.0",
   "devDependencies": {
     "acorn": "^8",
     "eslint": "^7",

--- a/test/test.js
+++ b/test/test.js
@@ -105,7 +105,7 @@ describe("acorn-private-methods", function () {
             static: false,
             computed: false,
             key: newNode(body.end + 2, {
-              type: "PrivateName",
+              type: "PrivateIdentifier",
               end: body.end + 4,
               name: "y"
             }),
@@ -224,7 +224,7 @@ describe("acorn-private-methods", function () {
       end: start + 7,
       computed: false,
       key: newNode(start, {
-        type: "PrivateName",
+        type: "PrivateIdentifier",
         end: start + 2,
         name: "x"
       }),
@@ -250,7 +250,7 @@ describe("acorn-private-methods", function () {
       end: start + 11,
       computed: false,
       key: newNode(start + 4, {
-        type: "PrivateName",
+        type: "PrivateIdentifier",
         end: start + 6,
         name: "x"
       }),


### PR DESCRIPTION
PrivateName -> PrivateIdentifier
privateNameToken -> privateIdentifierToken

This follows https://github.com/acornjs/acorn-private-class-elements/pull/16 and precedes a update to acorn-stage3.